### PR TITLE
Include conference start and end dates in iCalendar export

### DIFF
--- a/_layouts/calendar.ics
+++ b/_layouts/calendar.ics
@@ -3,29 +3,58 @@ METHOD:PUBLISH
 VERSION:2.0
 PRODID:-//{{ site.domain }}//conference-deadlines//EN
 X-PUBLISHED-TTL:PT1H
+
 {%- for conf in site.data.conferences -%}
+
 {% if conf.abstract_deadline and conf.abstract_deadline != "TBA" %}
 BEGIN:VEVENT
 SUMMARY:{{ conf.title }} {{ conf.year }} abstract deadline
 UID:{{ conf.id }}-abstract {% if conf.timezone contains "UTC" %} {% assign tz = conf.timezone | split: "UTC" %} {% if tz[1] contains "-" %} {% assign tz = tz[1] | replace: "-", "+" %} {% else if tz[1] contains "+" %} {% assign tz = tz[1] | replace: "+", "-" %} {% else assign tz = tz[1] %} {% endif %}
-ORGANIZER:https://pages.github.qmul.ac.uk/hhy553/bioinformatics-conferences/
+ORGANIZER:{{ site.baseurl }}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID=Etc/GMT{{ tz }}:{{ conf.abstract_deadline | date: "%Y%m%dT%H%M%S" }}
 {% else %}
-ORGANIZER:https://pages.github.qmul.ac.uk/hhy553/bioinformatics-conferences/
+ORGANIZER:{{ site.baseurl }}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID={{ conf.timezone }}:{{ conf.abstract_deadline | date: "%Y%m%dT%H%M%S" }}
-{% endif %}END:VEVENT{% endif %}
-{% if conf.deadline != "TBA" %}BEGIN:VEVENT
+{% endif %}
+END:VEVENT
+{% endif %}
+
+{% if conf.deadline != "TBA" %}
+BEGIN:VEVENT
 SUMMARY:{{ conf.title }} {{ conf.year }} deadline
 UID:{{ conf.id }} {% if conf.timezone contains "UTC" %} {% assign tz = conf.timezone | split: "UTC" %} {% if tz[1] contains "-" %} {% assign tz = tz[1] | replace: "-", "+" %} {% else if tz[1] contains "+" %} {% assign tz = tz[1] | replace: "+", "-" %} {% else assign tz = tz[1] %} {% endif %}
-ORGANIZER:https://pages.github.qmul.ac.uk/hhy553/bioinformatics-conferences/
+ORGANIZER:{{ site.baseurl }}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID=Etc/GMT{{ tz }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
 {% else %}
-ORGANIZER:https://pages.github.qmul.ac.uk/hhy553/bioinformatics-conferences/
+ORGANIZER:{{ site.baseurl }}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID={{ conf.timezone }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
-{% endif %}END:VEVENT
 {% endif %}
-{%- endfor -%}END:VCALENDAR
+END:VEVENT
+{% endif %}
+
+{% if conf.start and conf.end %}
+BEGIN:VEVENT
+SUMMARY:{{ conf.title }} {{ conf.year }}
+UID:{{ conf.id }} {% if conf.timezone contains "UTC" %} {% assign tz = conf.timezone | split: "UTC" %} {% if tz[1] contains "-" %} {% assign tz = tz[1] | replace: "-", "+" %} {% else if tz[1] contains "+" %} {% assign tz = tz[1] | replace: "+", "-" %} {% else assign tz = tz[1] %} {% endif %}
+ORGANIZER:{{ site.baseurl }}
+DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
+DTSTART;TZID=Etc/GMT{{ tz }}:{{ conf.start | date: "%Y%m%d "}}
+{% assign end_date = conf.end | date: "%s" | plus: 86400 | date: "%Y%m%dT%H%M%S" %}
+DTEND;TZID=Etc/GMT{{ tz }}:{{ end_date | date: "%Y%m%d" }}
+{% else %}
+ORGANIZER:{{ site.baseurl }}
+DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
+DTSTART;TZID={{ conf.timezone }}:{{ conf.start | date: "%Y%m%d" }}
+{% assign end_date = conf.end | date: "%s" | plus: 86400 | date: "%Y%m%dT%H%M%S" %}
+DTEND;TZID={{ conf.timezone }}:{{ end_date | date: "%Y%m%d" }}
+{% endif %}
+END:VEVENT
+{% endif %}
+
+
+{%- endfor -%}
+END:VCALENDAR


### PR DESCRIPTION
The exported iCalendar (`.ics`) file now includes conference start and end dates, alongside conference abstract and submission deadlines - this is now the default, there is no support for an export which _just_ includes deadlines, but I could support that if needs be?

@hlnicholls I recommend you also test an export/import, I could have been more exhaustive.

Resolves #1 